### PR TITLE
attachment-id-fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>de.bwl.lgl.jira.client</groupId>
   <artifactId>de-bwl-lgl-jira-client</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
 
   <name>de-bwl-lgl-jira-client</name>
@@ -41,6 +41,12 @@
     <artifactId>oss-parent</artifactId>
     <version>7</version>
   </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 
   <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>de.bwl.lgl.jira.client</groupId>

--- a/src/main/java/net/rcarz/jiraclient/Attachment.java
+++ b/src/main/java/net/rcarz/jiraclient/Attachment.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -61,7 +62,10 @@ public class Attachment extends Resource {
         Map map = json;
 
         self = Field.getString(map.get("self"));
-        id = getAttachmentId();
+        id = Field.getString(map.get("id"));
+        if (StringUtils.isEmpty(id)) {
+            id = getAttachmentId();
+        }
         author = Field.getResource(User.class, map.get("author"), restclient);
         filename = Field.getString(map.get("filename"));
         created = Field.getDate(map.get("created"));

--- a/src/main/java/net/rcarz/jiraclient/Attachment.java
+++ b/src/main/java/net/rcarz/jiraclient/Attachment.java
@@ -61,7 +61,7 @@ public class Attachment extends Resource {
         Map map = json;
 
         self = Field.getString(map.get("self"));
-        id = Field.getString(map.get("id"));
+        id = getAttachmentId();
         author = Field.getResource(User.class, map.get("author"), restclient);
         filename = Field.getString(map.get("filename"));
         created = Field.getDate(map.get("created"));
@@ -153,6 +153,11 @@ public class Attachment extends Resource {
 
     public int getSize() {
         return size;
+    }
+
+    private String getAttachmentId() {
+        String[] parts = self.split("/");
+        return parts[parts.length-1];
     }
 }
 

--- a/src/test/java/net/rcarz/jiraclient/AttachmentTest.java
+++ b/src/test/java/net/rcarz/jiraclient/AttachmentTest.java
@@ -1,0 +1,70 @@
+package net.rcarz.jiraclient;
+
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AttachmentTest {
+
+    @Test
+    public void testId() {
+        assertEquals("99248", attachment().getId());
+    }
+
+    @Test
+    public void testName() {
+        assertEquals("foobar.log", attachment().getFileName());
+    }
+
+    @Test
+    public void testSize() {
+        assertEquals(53, attachment().getSize());
+    }
+
+    @Test
+    public void testMimeType() {
+        assertEquals("text/plain", attachment().getMimeType());
+    }
+
+    @Test
+    public void testContentUrl() {
+        assertEquals("http://localhost:8080/secure/attachment/99248/foobar.log", attachment().getContentUrl());
+    }
+
+    @Test
+    public void testAuthor() {
+        assertEquals("admin", attachment().getAuthor().getName());
+    }
+
+    private Attachment attachment() {
+        return new Attachment(null, getTestJson());
+    }
+
+    private JSONObject getTestJson() {
+        return (JSONObject) JSONSerializer.toJSON(
+                "{\n" +
+                    "\"self\": \"http://localhost:8080/rest/api/2/attachment/99248\",\n" +
+                    "\"filename\": \"foobar.log\",\n" +
+                    "\"author\": {\n" +
+                        "\"self\": \"http://localhost:8080/rest/api/2/user?username=admin\",\n" +
+                        "\"key\": \"admin\",\n" +
+                        "\"name\": \"admin\",\n" +
+                        "\"avatarUrls\": {\n" +
+                            "\"48x48\": \"http://localhost:8080/secure/useravatar?ownerId=admin&avatarId=18600\",\n" +
+                            "\"24x24\": \"http://localhost:8080/secure/useravatar?size=small&ownerId=admin&avatarId=18600\",\n" +
+                            "\"16x16\": \"http://localhost:8080/secure/useravatar?size=xsmall&ownerId=admin&avatarId=18600\",\n" +
+                            "\"32x32\": \"http://localhost:8080/secure/useravatar?size=medium&ownerId=admin&avatarId=18600\"\n" +
+                            "},\n" +
+                        "\"displayName\": \"admin\",\n" +
+                        "\"active\": true\n" +
+                    "},\n" +
+                    "\"created\": \"2021-03-12T16:35:48.287+0100\",\n" +
+                    "\"size\": 53,\n" +
+                    "\"mimeType\": \"text/plain\",\n" +
+                    "\"properties\": { },\n" +
+                    "\"content\": \"http://localhost:8080/secure/attachment/99248/foobar.log\"\n" +
+                "}");
+    }
+}

--- a/src/test/java/net/rcarz/jiraclient/AttachmentTest.java
+++ b/src/test/java/net/rcarz/jiraclient/AttachmentTest.java
@@ -11,6 +11,7 @@ public class AttachmentTest {
     @Test
     public void testId() {
         assertEquals("99248", attachment().getId());
+        assertEquals("2345", new Attachment(null, getTestJsonWithId()).getId());
     }
 
     @Test
@@ -39,10 +40,10 @@ public class AttachmentTest {
     }
 
     private Attachment attachment() {
-        return new Attachment(null, getTestJson());
+        return new Attachment(null, getTestJsonWithoutId());
     }
 
-    private JSONObject getTestJson() {
+    private JSONObject getTestJsonWithoutId() {
         return (JSONObject) JSONSerializer.toJSON(
                 "{\n" +
                     "\"self\": \"http://localhost:8080/rest/api/2/attachment/99248\",\n" +
@@ -66,5 +67,32 @@ public class AttachmentTest {
                     "\"properties\": { },\n" +
                     "\"content\": \"http://localhost:8080/secure/attachment/99248/foobar.log\"\n" +
                 "}");
+    }
+
+    private JSONObject getTestJsonWithId() {
+        return (JSONObject) JSONSerializer.toJSON(
+                "{\n" +
+                        "\"self\": \"http://localhost:8080/rest/api/2/attachment/99248\",\n" +
+                        "\"filename\": \"foobar.log\",\n" +
+                        "\"author\": {\n" +
+                        "\"self\": \"http://localhost:8080/rest/api/2/user?username=admin\",\n" +
+                        "\"key\": \"admin\",\n" +
+                        "\"name\": \"admin\",\n" +
+                        "\"avatarUrls\": {\n" +
+                        "\"48x48\": \"http://localhost:8080/secure/useravatar?ownerId=admin&avatarId=18600\",\n" +
+                        "\"24x24\": \"http://localhost:8080/secure/useravatar?size=small&ownerId=admin&avatarId=18600\",\n" +
+                        "\"16x16\": \"http://localhost:8080/secure/useravatar?size=xsmall&ownerId=admin&avatarId=18600\",\n" +
+                        "\"32x32\": \"http://localhost:8080/secure/useravatar?size=medium&ownerId=admin&avatarId=18600\"\n" +
+                        "},\n" +
+                        "\"displayName\": \"admin\",\n" +
+                        "\"active\": true\n" +
+                        "},\n" +
+                        "\"created\": \"2021-03-12T16:35:48.287+0100\",\n" +
+                        "\"size\": 53,\n" +
+                        "\"id\": \"2345\",\n" +
+                        "\"mimeType\": \"text/plain\",\n" +
+                        "\"properties\": { },\n" +
+                        "\"content\": \"http://localhost:8080/secure/attachment/99248/foobar.log\"\n" +
+                        "}");
     }
 }


### PR DESCRIPTION
Attachment.getId() liefert nun nicht mehr null, wenn nicht vorhanden.
POM: Maven-Namespace URIs ohne https